### PR TITLE
Avoid org.embulk.spi.json.JsonParseException: Unable to parse empty string

### DIFF
--- a/src/main/java/org/embulk/parser/jsonl/JsonlParserPlugin.java
+++ b/src/main/java/org/embulk/parser/jsonl/JsonlParserPlugin.java
@@ -18,6 +18,7 @@ import org.embulk.spi.PageOutput;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.SchemaConfig;
+import org.embulk.spi.json.JsonParseException;
 import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.util.LineDecoder;
@@ -228,7 +229,7 @@ public class JsonlParserPlugin
 
                         pageBuilder.addRecord();
                     }
-                    catch (JsonRecordValidateException e) {
+                    catch (JsonRecordValidateException | JsonParseException e) {
                         if (stopOnInvalidRecord) {
                             throw new DataException(String.format("Invalid record at line %d: %s", lineNumber, line), e);
                         }

--- a/src/test/java/org/embulk/parser/jsonl/TestJsonlParserPlugin.java
+++ b/src/test/java/org/embulk/parser/jsonl/TestJsonlParserPlugin.java
@@ -76,7 +76,8 @@ public class TestJsonlParserPlugin
                 "10",
                 "true",
                 "false",
-                "null"
+                "null",
+                " "
         ));
 
         List<Object[]> records = Pages.toObjects(schema.toSchema(), output.pages);


### PR DESCRIPTION
Hi, @muga @shun0102 
When the JsonParser parses empty string, this throws `JsonParseException`, this plugin does not catch the exception though this plugin has `stop_on_invalid_record` option.
So, I add the code that catch  `JsonParseException`.
